### PR TITLE
Add a special container for views

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ julia> ones(Int, 2,3,4)[:, *, 4]
  [1, 1]
 
 julia> @view ones(Int, 2,3)[*, :]
-2-element Array{SubArray{Int64,1,Array{Int64,2},Tuple{Int64,Base.Slice{Base.OneTo{Int64}}},true},1}:
+2-element star_views(::Array{Int64,2}, (*, :)):
  [1, 1, 1]
  [1, 1, 1]
 

--- a/src/eachslice32310.jl
+++ b/src/eachslice32310.jl
@@ -1,0 +1,45 @@
+# https://github.com/JuliaLang/julia/pull/32310/files
+
+struct EachSlice{A,I,L}
+    arr::A # underlying array
+    cartiter::I # CartesianIndices iterator
+    lookup::L # dimension look up: dimension index in cartiter, or nothing
+end
+
+function iterate(s::EachSlice, state...)
+    r = iterate(s.cartiter, state...)
+    r === nothing && return r
+    (c,nextstate) = r
+    view(s.arr, map(l -> l === nothing ? (:) : c[l], s.lookup)...), nextstate
+end
+
+size(s::EachSlice) = size(s.cartiter)
+length(s::EachSlice) = length(s.cartiter)
+ndims(s::EachSlice) = ndims(s.cartiter)
+IteratorSize(::Type{EachSlice{A,I,L}}) where {A,I,L} = IteratorSize(I)
+IteratorEltype(::Type{EachSlice{A,I,L}}) where {A,I,L} = EltypeUnknown()
+
+parent(s::EachSlice) = s.arr
+
+function eachrow(A::AbstractVecOrMat)
+    iter = CartesianIndices((axes(A,1),))
+    lookup = (1,nothing)
+    EachSlice(A,iter,lookup)
+end
+const EachRow{A,I} = EachSlice{A,I,Tuple{Int,Nothing}}
+
+function eachcol(A::AbstractVecOrMat)
+    iter = CartesianIndices((axes(A,2),))
+    lookup = (nothing,1)
+    EachSlice(A,iter,lookup)
+end
+const EachCol{A,I} = EachSlice{A,I,Tuple{Nothing,Int}}
+
+@inline function eachslice(A::AbstractArray; dims)
+    for dim in dims
+        dim <= ndims(A) || throw(DimensionMismatch("A doesn't have $dim dimensions"))
+    end
+    iter = CartesianIndices(map(dim -> axes(A,dim), dims))
+    lookup = ntuple(dim -> findfirst(isequal(dim), dims), ndims(A))
+    EachSlice(A,iter,lookup)
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -80,6 +80,11 @@ end
 
     A = rand(1:99, 2,3,4)
 
+    @test eltype(A[*,:,2]) == typeof(first(A[*,:,2]))
+    @test eltype(A[&,!,2]) == typeof(first(A[&,!,2]))
+    @test eltype(@view A[*,:,2]) == typeof(first(@view A[*,:,2]))
+    @test eltype(@view A[&,!,2]) == typeof(first(@view A[&,!,2]))
+
     @test (@inferred A[*,:,2]; true)
     @test (@inferred view(A,*,:,2); true)
     @test (@inferred first(view(A,*,:,2)); true)

--- a/test/speed.jl
+++ b/test/speed.jl
@@ -19,7 +19,7 @@ dodgy = stack(map(identity, eachslice(Z, :,*,1)))
 dodgy.slices[1][1] = 99
 dodgy
 
-#====== REPL =====#
+#====== mapslices, REPL =====#
 # An entirely trivial example:
 
 julia> A = rand(10,10,10);
@@ -123,7 +123,20 @@ julia> @btime map(g3, eachslice($B2, *,:,:));
 
 # Even here, the speed gain from re-using slice is minimal.
 
-# ================
+#====== reduction, REPL =====#
+
+julia> A = rand(10,10,10);
+
+julia> @btime sum($A, dims=(1,3));
+  1.022 μs (6 allocations: 352 bytes)
+
+julia> @btime sum.($A[!,*,!]);
+  1.765 μs (17 allocations: 9.16 KiB)
+
+julia> @btime sum.(@view $A[!,*,!]);
+  2.804 μs (17 allocations: 1.03 KiB)
+
+#====== umm =====#
 
 
 parent_type(A) = typeof(parent(A))


### PR DESCRIPTION
This makes `view(A, *, :)::Sliced` instead of an array of views. Which means that reductions can specialise, and act on `A` without ever creating the slices. The difficulty is figuring out what eltype this object should have.